### PR TITLE
Made `NSImage.symbol` optional

### DIFF
--- a/Sources/CodeEditSymbols/CodeEditSymbols.swift
+++ b/Sources/CodeEditSymbols/CodeEditSymbols.swift
@@ -43,8 +43,8 @@ public extension NSImage {
     /// Returns a NSImage representing a custom SF Symbol
     /// - Parameter named: The name of the symbol in `Symbols.xcassets`
     /// - Returns: a NSImage
-    static func symbol(named: String) -> NSImage {
-        Bundle.module.image(forResource: named) ?? .init()
+    static func symbol(named: String) -> NSImage? {
+        Bundle.module.image(forResource: named)
     }
 
     // MARK: - Symbols

--- a/Sources/CodeEditSymbols/CodeEditSymbols.swift
+++ b/Sources/CodeEditSymbols/CodeEditSymbols.swift
@@ -49,22 +49,22 @@ public extension NSImage {
 
     // MARK: - Symbols
 
-    static let vault: NSImage = .symbol(named: "vault")
-    static let vaultFill: NSImage = .symbol(named: "vault.fill")
-    static let commit: NSImage = .symbol(named: "commit")
-    static let checkout: NSImage = .symbol(named: "checkout")
-    static let branch: NSImage = .symbol(named: "branch")
-    static let breakpoint: NSImage = .symbol(named: "breakpoint")
-    static let breakpointFill: NSImage = .symbol(named: "breakpoint.fill")
-    static let chevronUpChevronDown: NSImage = .symbol(named: "chevron.up.chevron.down")
-    static let github: NSImage = .symbol(named: "github")
-    static let docJava: NSImage = .symbol(named: "doc.java")
-    static let docJavascript: NSImage = .symbol(named: "doc.javascript")
-    static let docJson: NSImage = .symbol(named: "doc.json")
-    static let docPython: NSImage = .symbol(named: "doc.python")
-    static let docRuby: NSImage = .symbol(named: "doc.ruby")
-    static let squareSplitHorizontalPlus: NSImage = .symbol(named: "square.split.horizontal.plus")
-    static let squareSplitVerticalPlus: NSImage = .symbol(named: "square.split.vertical.plus")
+    static let vault: NSImage? = .symbol(named: "vault")
+    static let vaultFill: NSImage? = .symbol(named: "vault.fill")
+    static let commit: NSImage? = .symbol(named: "commit")
+    static let checkout: NSImage? = .symbol(named: "checkout")
+    static let branch: NSImage? = .symbol(named: "branch")
+    static let breakpoint: NSImage? = .symbol(named: "breakpoint")
+    static let breakpointFill: NSImage? = .symbol(named: "breakpoint.fill")
+    static let chevronUpChevronDown: NSImage? = .symbol(named: "chevron.up.chevron.down")
+    static let github: NSImage? = .symbol(named: "github")
+    static let docJava: NSImage? = .symbol(named: "doc.java")
+    static let docJavascript: NSImage? = .symbol(named: "doc.javascript")
+    static let docJson: NSImage? = .symbol(named: "doc.json")
+    static let docPython: NSImage? = .symbol(named: "doc.python")
+    static let docRuby: NSImage? = .symbol(named: "doc.ruby")
+    static let squareSplitHorizontalPlus: NSImage? = .symbol(named: "square.split.horizontal.plus")
+    static let squareSplitVerticalPlus: NSImage? = .symbol(named: "square.split.vertical.plus")
     
     // add static properties for your symbols above this line
 


### PR DESCRIPTION
### Description

`NSImage` is optional by default. This makes `NSImage.symbol` optional so it is consistent with `NSImage`.